### PR TITLE
Fixed longDelivery2 test

### DIFF
--- a/src/test/java/io/vertx/serviceproxy/test/JSServiceProxyTest.java
+++ b/src/test/java/io/vertx/serviceproxy/test/JSServiceProxyTest.java
@@ -4,9 +4,12 @@ import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.serviceproxy.Addresses;
 import io.vertx.serviceproxy.ProxyHelper;
+import io.vertx.serviceproxy.ServiceBinder;
 import io.vertx.serviceproxy.testmodel.TestService;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -20,7 +23,7 @@ public class JSServiceProxyTest extends VertxTestBase {
   public void setUp() throws Exception {
     super.setUp();
     service = TestService.create(vertx);
-    consumer = ProxyHelper.registerService(TestService.class, vertx, service, Addresses.SERVICE_ADDRESS);
+    consumer = new ServiceBinder(vertx).setAddress(Addresses.SERVICE_ADDRESS).register(TestService.class, service);
     vertx.eventBus().<String>consumer(Addresses.TEST_ADDRESS).handler(msg -> {
       assertEquals("ok", msg.body());
       testComplete();
@@ -418,7 +421,7 @@ public class JSServiceProxyTest extends VertxTestBase {
   public void testConnectionTimeout() {
     consumer.unregister();
     long timeoutSeconds = 2;
-    consumer = ProxyHelper.registerService(TestService.class, vertx, service, Addresses.SERVICE_ADDRESS, timeoutSeconds);
+    consumer = new ServiceBinder(vertx).setAddress(Addresses.SERVICE_ADDRESS).setTimeoutSeconds(timeoutSeconds).register(TestService.class, service);
     deploy("test_service_connectionTimeout.js");
     await();
   }
@@ -427,7 +430,7 @@ public class JSServiceProxyTest extends VertxTestBase {
   public void testConnectionWithCloseFutureTimeout() {
     consumer.unregister();
     long timeoutSeconds = 2;
-    consumer = ProxyHelper.registerService(TestService.class, vertx, service, Addresses.SERVICE_ADDRESS, timeoutSeconds);
+    consumer = new ServiceBinder(vertx).setAddress(Addresses.SERVICE_ADDRESS).setTimeoutSeconds(timeoutSeconds).register(TestService.class, service);
     deploy("test_service_connectionWithCloseFutureTimeout.js");
     await();
   }

--- a/src/test/java/io/vertx/serviceproxy/testmodel/impl/TestServiceImpl.java
+++ b/src/test/java/io/vertx/serviceproxy/testmodel/impl/TestServiceImpl.java
@@ -523,6 +523,6 @@ public class TestServiceImpl implements TestService {
 
   @Override
   public void longDeliveryFailed(Handler<AsyncResult<String>> resultHandler) {
-    vertx.setTimer(30*1000L, tid -> resultHandler.handle(Future.succeededFuture("blah")));
+    vertx.setTimer(30*1000L, tid -> resultHandler.handle(Future.failedFuture("blah")));
   }
 }


### PR DESCRIPTION
Related to https://travis-ci.org/vert-x3/vertx-sockjs-service-proxy/jobs/499299770
Also removed usage of ProxyHelper, replaced with ServiceBinder