### PR TITLE
Re enable test running using graaljs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
   <properties>
     <codegen.rxjava.deprecated>true</codegen.rxjava.deprecated>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
-    <es4x.version>0.11.1-SNAPSHOT</es4x.version>
     <graalvm.version>20.0.0</graalvm.version>
   </properties>
 
@@ -75,12 +74,6 @@
       <classifier>client</classifier>
       <scope>test</scope>
       <type>js</type>
-    </dependency>
-    <dependency>
-      <groupId>io.reactiverse</groupId>
-      <artifactId>es4x</artifactId>
-      <version>${es4x.version}</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -197,24 +190,6 @@
               <includeClassifiers>client</includeClassifiers>
               <outputDirectory>${project.build.testOutputDirectory}/vertx-js</outputDirectory>
               <stripVersion>true</stripVersion>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.8</version>
-        <executions>
-          <execution>
-            <id>rename-vertx-eventbus</id>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <phase>process-test-resources</phase>
-            <configuration>
-              <target>
-                <move file="${project.build.testOutputDirectory}/vertx-js/vertx-web-client.js" tofile="${project.build.testOutputDirectory}/vertx-js/vertx-eventbus.js"/>
-              </target>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,8 @@
   <properties>
     <codegen.rxjava.deprecated>true</codegen.rxjava.deprecated>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
+    <es4x.version>0.11.1-SNAPSHOT</es4x.version>
+    <graalvm.version>20.0.0</graalvm.version>
   </properties>
 
   <dependencyManagement>
@@ -52,13 +54,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
-      <classifier>client</classifier>
-      <scope>test</scope>
-      <type>js</type>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-web</artifactId>
     </dependency>
 
     <!-- Testing -->
@@ -74,7 +69,58 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+      <classifier>client</classifier>
+      <scope>test</scope>
+      <type>js</type>
+    </dependency>
+    <dependency>
+      <groupId>io.reactiverse</groupId>
+      <artifactId>es4x</artifactId>
+      <version>${es4x.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>graaljs</id>
+      <activation>
+        <file>
+          <missing>${java.home}/../GRAALVM-README.md</missing>
+        </file>
+      </activation>
+      <dependencies>
+        <!-- GraalVM runtime -->
+        <dependency>
+          <groupId>org.graalvm.truffle</groupId>
+          <artifactId>truffle-api</artifactId>
+          <version>${graalvm.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.graalvm.js</groupId>
+          <artifactId>js</artifactId>
+          <version>${graalvm.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.graalvm.tools</groupId>
+          <artifactId>profiler</artifactId>
+          <version>${graalvm.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.graalvm.tools</groupId>
+          <artifactId>chromeinspector</artifactId>
+          <version>${graalvm.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
   <build>
     <pluginManagement>
@@ -95,12 +141,6 @@
               </configuration>
             </execution>
           </executions>
-        </plugin>
-        <plugin>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
         </plugin>
       </plugins>
 

--- a/src/main/java/io/vertx/serviceproxy/sockjs/generator/SockjsServiceProxyJSGenerator.java
+++ b/src/main/java/io/vertx/serviceproxy/sockjs/generator/SockjsServiceProxyJSGenerator.java
@@ -246,7 +246,7 @@ public class SockjsServiceProxyJSGenerator extends AbstractSockjsServiceProxyGen
     for (ApiTypeInfo referencedType : model.getReferencedTypes()) {
       if(referencedType.isProxyGen()) {
         String refedType = referencedType.getSimpleName();
-        writer.format("var %s = require('%s-proxy');", refedType, getModuleName(referencedType)).println();
+        writer.format("var %s = require('./%s-proxy');", refedType, getModuleName(referencedType)).println();
       }
     }
     writer.println();

--- a/src/test/java/io/vertx/serviceproxy/test/JSServiceProxyTest.java
+++ b/src/test/java/io/vertx/serviceproxy/test/JSServiceProxyTest.java
@@ -6,7 +6,12 @@ import io.vertx.serviceproxy.Addresses;
 import io.vertx.serviceproxy.ProxyHelper;
 import io.vertx.serviceproxy.testmodel.TestService;
 import io.vertx.test.core.VertxTestBase;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Source;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -27,13 +32,34 @@ public class JSServiceProxyTest extends VertxTestBase {
     });
   }
 
-  private void deploy(String test) {
-    vertx.deployVerticle(test, ar -> {
-      if (ar.failed()) {
-        ar.cause().printStackTrace();
-      }
-      assertTrue(ar.succeeded());
-    });
+  private static void eval(Context context, String filename) {
+    try {
+      context.eval(
+        Source.newBuilder(
+          "js",
+          new InputStreamReader(JSBusTest.class.getResourceAsStream(filename)), filename).build());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void execute(String script) {
+    try (Context context = Context.newBuilder("js").allowAllAccess(true).build()) {
+      context.getBindings("js").putMember("vertx", vertx);
+      // load sockjs mock
+      eval(context, "/node_modules/sockjs-client.js");
+      // load sockjs client
+      eval(context, "/vertx-js/vertx-web-client.js");
+      // load the service dependencies
+      eval(context, "/test-js/test_connection-proxy.js");
+      eval(context, "/test-js/test_connection_with_close_future-proxy.js");
+      // load the service
+      eval(context, "/test-js/test_service-proxy.js");
+
+      // load the test
+      vertx.runOnContext(v -> eval(context, script));
+      await();
+    }
   }
 
   @Override
@@ -44,374 +70,313 @@ public class JSServiceProxyTest extends VertxTestBase {
 
   @Test
   public void testInvalidParams() {
-    deploy("test_service_invalidParams.js");
-    await();
+    execute("/test_service_invalidParams.js");
   }
 
   @Test
   public void testNoParams() {
-    deploy("test_service_noParams.js");
-    await();
+    execute("/test_service_noParams.js");
   }
 
   @Test
   public void testBasicTypes() {
-    deploy("test_service_basicTypes.js");
-    await();
+    execute("/test_service_basicTypes.js");
   }
 
   @Test
   public void testBasicBoxedTypes() {
-    deploy("test_service_basicBoxedTypes.js");
-    await();
+    execute("/test_service_basicBoxedTypes.js");
   }
 
   @Test
   public void testJsonTypes() {
-    deploy("test_service_jsonTypes.js");
-    await();
+    execute("/test_service_jsonTypes.js");
   }
 
   @Test
   public void testEnumType() {
-    deploy("test_service_enumType.js");
-    await();
+    execute("/test_service_enumType.js");
   }
 
   @Test
   public void testDataObjectType() {
-    deploy("test_service_dataObjectType.js");
-    await();
+    execute("/test_service_dataObjectType.js");
   }
 
   @Test
   public void testListTypes() {
-    deploy("test_service_listTypes.js");
-    await();
+    execute("/test_service_listTypes.js");
   }
 
   @Test
   public void testSetTypes() {
-    deploy("test_service_setTypes.js");
-    await();
+    execute("/test_service_setTypes.js");
   }
 
   @Test
   public void testMapTypes() {
-    deploy("test_service_mapTypes.js");
-    await();
+    execute("/test_service_mapTypes.js");
   }
 
   @Test
   public void testStringHandler() {
-    deploy("test_service_stringHandler.js");
-    await();
+    execute("/test_service_stringHandler.js");
   }
 
   @Test
   public void testStringNullHandler() {
-    deploy("test_service_stringNullHandler.js");
-    await();
+    execute("/test_service_stringNullHandler.js");
   }
 
   @Test
   public void testByteHandler() {
-    deploy("test_service_byteHandler.js");
-    await();
+    execute("/test_service_byteHandler.js");
   }
 
   @Test
   public void testByteNullHandler() {
-    deploy("test_service_byteNullHandler.js");
-    await();
+    execute("/test_service_byteNullHandler.js");
   }
 
   @Test
   public void testShortHandler() {
-    deploy("test_service_shortHandler.js");
-    await();
+    execute("/test_service_shortHandler.js");
   }
 
   @Test
   public void testShortNullHandler() {
-    deploy("test_service_shortNullHandler.js");
-    await();
+    execute("/test_service_shortNullHandler.js");
   }
 
   @Test
   public void testIntHandler() {
-    deploy("test_service_intHandler.js");
-    await();
+    execute("/test_service_intHandler.js");
   }
 
   @Test
   public void testIntNullHandler() {
-    deploy("test_service_intNullHandler.js");
-    await();
+    execute("/test_service_intNullHandler.js");
   }
 
   @Test
   public void testLongHandler() {
-    deploy("test_service_longHandler.js");
-    await();
+    execute("/test_service_longHandler.js");
   }
 
   @Test
   public void testLongNullHandler() {
-    deploy("test_service_longNullHandler.js");
-    await();
+    execute("/test_service_longNullHandler.js");
   }
 
   @Test
   public void testFloatHandler() {
-    deploy("test_service_floatHandler.js");
-    await();
+    execute("/test_service_floatHandler.js");
   }
 
   @Test
   public void testFloatNullHandler() {
-    deploy("test_service_floatNullHandler.js");
-    await();
+    execute("/test_service_floatNullHandler.js");
   }
 
   @Test
   public void testDoubleHandler() {
-    deploy("test_service_doubleHandler.js");
-    await();
+    execute("/test_service_doubleHandler.js");
   }
 
   @Test
   public void testDoubleNullHandler() {
-    deploy("test_service_doubleNullHandler.js");
-    await();
+    execute("/test_service_doubleNullHandler.js");
   }
 
   @Test
   public void testCharHandler() {
-    deploy("test_service_charHandler.js");
-    await();
+    execute("/test_service_charHandler.js");
   }
 
   @Test
   public void testCharNullHandler() {
-    deploy("test_service_charNullHandler.js");
-    await();
+    execute("/test_service_charNullHandler.js");
   }
 
   @Test
   public void testJsonObjectHandler() {
-    deploy("test_service_jsonObjectHandler.js");
-    await();
+    execute("/test_service_jsonObjectHandler.js");
   }
 
   @Test
   public void testJsonObjectNullHandler() {
-    deploy("test_service_jsonObjectNullHandler.js");
-    await();
+    execute("/test_service_jsonObjectNullHandler.js");
   }
 
   @Test
   public void testJsonArrayHandler() {
-    deploy("test_service_jsonArrayHandler.js");
-    await();
+    execute("/test_service_jsonArrayHandler.js");
   }
 
   @Test
   public void testJsonArrayNullHandler() {
-    deploy("test_service_jsonArrayNullHandler.js");
-    await();
+    execute("/test_service_jsonArrayNullHandler.js");
   }
 
   @Test
   public void testDataObjectHandler() {
-    deploy("test_service_dataObjectHandler.js");
-    await();
+    execute("/test_service_dataObjectHandler.js");
   }
 
   @Test
   public void testDataObjectNullHandler() {
-    deploy("test_service_dataObjectNullHandler.js");
-    await();
+    execute("/test_service_dataObjectNullHandler.js");
   }
 
   @Test
   public void testVoidHandler() {
-    deploy("test_service_voidHandler.js");
-    await();
+    execute("/test_service_voidHandler.js");
   }
 
   @Test
   public void testFluentMethod() {
-    deploy("test_service_fluentMethod.js");
-    await();
+    execute("/test_service_fluentMethod.js");
   }
 
   @Test
   public void testFluentNoParams() {
-    deploy("test_service_fluentNoParams.js");
-    await();
+    execute("/test_service_fluentNoParams.js");
   }
 
   @Test
   public void testFailingMethod() {
-    deploy("test_service_failingMethod.js");
-    await();
+    execute("/test_service_failingMethod.js");
   }
 
   @Test
   public void testListStringHandler() {
-    deploy("test_service_listStringHandler.js");
-    await();
+    execute("/test_service_listStringHandler.js");
   }
 
   @Test
   public void testListByteHandler() {
-    deploy("test_service_listByteHandler.js");
-    await();
+    execute("/test_service_listByteHandler.js");
   }
 
   @Test
   public void testListShortHandler() {
-    deploy("test_service_listShortHandler.js");
-    await();
+    execute("/test_service_listShortHandler.js");
   }
 
   @Test
   public void testListIntHandler() {
-    deploy("test_service_listIntHandler.js");
-    await();
+    execute("/test_service_listIntHandler.js");
   }
 
   @Test
   public void testListLongHandler() {
-    deploy("test_service_listLongHandler.js");
-    await();
+    execute("/test_service_listLongHandler.js");
   }
 
   @Test
   public void testListFloatHandler() {
-    deploy("test_service_listFloatHandler.js");
-    await();
+    execute("/test_service_listFloatHandler.js");
   }
 
   @Test
   public void testListDoubleHandler() {
-    deploy("test_service_listDoubleHandler.js");
-    await();
+    execute("/test_service_listDoubleHandler.js");
   }
 
   @Test
   public void testListCharHandler() {
-    deploy("test_service_listCharHandler.js");
-    await();
+    execute("/test_service_listCharHandler.js");
   }
 
   @Test
   public void testListBoolHandler() {
-    deploy("test_service_listBoolHandler.js");
-    await();
+    execute("/test_service_listBoolHandler.js");
   }
 
   @Test
   public void testListJsonObjectHandler() {
-    deploy("test_service_listJsonObjectHandler.js");
-    await();
+    execute("/test_service_listJsonObjectHandler.js");
   }
 
   @Test
   public void testListJsonArrayHandler() {
-    deploy("test_service_listJsonArrayHandler.js");
-    await();
+    execute("/test_service_listJsonArrayHandler.js");
   }
 
   @Test
   public void testListDataObjectHandler() {
-    deploy("test_service_listDataObjectHandler.js");
-    await();
+    execute("/test_service_listDataObjectHandler.js");
   }
 
   @Test
   public void testSetStringHandler() {
-    deploy("test_service_setStringHandler.js");
-    await();
+    execute("/test_service_setStringHandler.js");
+
   }
 
   @Test
   public void testSetByteHandler() {
-    deploy("test_service_setByteHandler.js");
-    await();
+    execute("/test_service_setByteHandler.js");
   }
 
   @Test
   public void testSetShortHandler() {
-    deploy("test_service_setShortHandler.js");
-    await();
+    execute("/test_service_setShortHandler.js");
   }
 
   @Test
   public void testSetIntHandler() {
-    deploy("test_service_setIntHandler.js");
-    await();
+    execute("/test_service_setIntHandler.js");
   }
 
   @Test
   public void testSetLongHandler() {
-    deploy("test_service_setLongHandler.js");
-    await();
+    execute("/test_service_setLongHandler.js");
   }
 
   @Test
   public void testSetFloatHandler() {
-    deploy("test_service_setFloatHandler.js");
-    await();
+    execute("/test_service_setFloatHandler.js");
   }
 
   @Test
   public void testSetDoubleHandler() {
-    deploy("test_service_setDoubleHandler.js");
-    await();
+    execute("/test_service_setDoubleHandler.js");
   }
 
   @Test
   public void testSetCharHandler() {
-    deploy("test_service_setCharHandler.js");
-    await();
+    execute("/test_service_setCharHandler.js");
   }
 
   @Test
   public void testSetBoolHandler() {
-    deploy("test_service_setBoolHandler.js");
-    await();
+    execute("/test_service_setBoolHandler.js");
   }
 
   @Test
   public void testSetJsonObjectHandler() {
-    deploy("test_service_setJsonObjectHandler.js");
-    await();
+    execute("/test_service_setJsonObjectHandler.js");
   }
 
   @Test
   public void testSetJsonArrayHandler() {
-    deploy("test_service_setJsonArrayHandler.js");
-    await();
+    execute("/test_service_setJsonArrayHandler.js");
   }
 
   @Test
   public void testSetDataObjectHandler() {
-    deploy("test_service_setDataObjectHandler.js");
-    await();
+    execute("/test_service_setDataObjectHandler.js");
   }
 
   @Test
   public void testProxyIgnore() {
-    deploy("test_service_proxyIgnore.js");
-    await();
+    execute("/test_service_proxyIgnore.js");
   }
 
   @Test
   public void testConnection() {
-    deploy("test_service_connection.js");
-    await();
+    execute("/test_service_connection.js");
   }
 
   @Test
@@ -419,8 +384,7 @@ public class JSServiceProxyTest extends VertxTestBase {
     consumer.unregister();
     long timeoutSeconds = 2;
     consumer = ProxyHelper.registerService(TestService.class, vertx, service, Addresses.SERVICE_ADDRESS, timeoutSeconds);
-    deploy("test_service_connectionTimeout.js");
-    await();
+    execute("/test_service_connectionTimeout.js");
   }
 
   @Test
@@ -428,19 +392,16 @@ public class JSServiceProxyTest extends VertxTestBase {
     consumer.unregister();
     long timeoutSeconds = 2;
     consumer = ProxyHelper.registerService(TestService.class, vertx, service, Addresses.SERVICE_ADDRESS, timeoutSeconds);
-    deploy("test_service_connectionWithCloseFutureTimeout.js");
-    await();
+    execute("/test_service_connectionWithCloseFutureTimeout.js");
   }
 
   @Test
   public void testLongDelivery1() {
-    deploy("test_service_longDeliverySuccess.js");
-    await();
+    execute("/test_service_longDeliverySuccess.js");
   }
 
   @Test
   public void testLongDelivery2() {
-    deploy("test_service_longDeliveryFailed.js");
-    await();
+    execute("/test_service_longDeliveryFailed.js");
   }
 }

--- a/src/test/resources/bus_test_reconnect.js
+++ b/src/test/resources/bus_test_reconnect.js
@@ -1,11 +1,10 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
 var bus = new EventBus();
 bus.enableReconnect(true);
 
 bus.onopen = function () {
-  setTimeout(function () {
+  vertx.setTimer(250, function () {
   	bus.sockJSConn.close();
-  }, 250);
+  });
 };
 
 bus.onreconnect = function () {

--- a/src/test/resources/bus_test_reconnect.js
+++ b/src/test/resources/bus_test_reconnect.js
@@ -1,4 +1,4 @@
-var EventBus = require('vertx-js/vertx-eventbus');
+var EventBus = require('./vertx-js/vertx-eventbus');
 var bus = new EventBus();
 bus.enableReconnect(true);
 

--- a/src/test/resources/bus_test_send_1.js
+++ b/src/test/resources/bus_test_send_1.js
@@ -1,4 +1,4 @@
-var EventBus = require('vertx-js/vertx-eventbus');
+var EventBus = require('./vertx-js/vertx-eventbus');
 var bus = new EventBus();
 
 bus.onopen = function () {

--- a/src/test/resources/bus_test_send_1.js
+++ b/src/test/resources/bus_test_send_1.js
@@ -1,4 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
 var bus = new EventBus();
 
 bus.onopen = function () {

--- a/src/test/resources/bus_test_send_2.js
+++ b/src/test/resources/bus_test_send_2.js
@@ -1,4 +1,4 @@
-var EventBus = require('vertx-js/vertx-eventbus');
+var EventBus = require('./vertx-js/vertx-eventbus');
 var bus = new EventBus();
 
 bus.onopen = function () {

--- a/src/test/resources/bus_test_send_2.js
+++ b/src/test/resources/bus_test_send_2.js
@@ -1,4 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
 var bus = new EventBus();
 
 bus.onopen = function () {

--- a/src/test/resources/bus_test_send_3.js
+++ b/src/test/resources/bus_test_send_3.js
@@ -1,4 +1,4 @@
-var EventBus = require('vertx-js/vertx-eventbus');
+var EventBus = require('./vertx-js/vertx-eventbus');
 var bus = new EventBus();
 
 bus.onopen = function () {

--- a/src/test/resources/bus_test_send_3.js
+++ b/src/test/resources/bus_test_send_3.js
@@ -1,4 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
 var bus = new EventBus();
 
 bus.onopen = function () {

--- a/src/test/resources/bus_test_send_4.js
+++ b/src/test/resources/bus_test_send_4.js
@@ -1,4 +1,4 @@
-var EventBus = require('vertx-js/vertx-eventbus');
+var EventBus = require('./vertx-js/vertx-eventbus');
 var bus = new EventBus();
 
 bus.onopen = function () {

--- a/src/test/resources/bus_test_send_4.js
+++ b/src/test/resources/bus_test_send_4.js
@@ -1,4 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
 var bus = new EventBus();
 
 bus.onopen = function () {

--- a/src/test/resources/bus_test_send_5.js
+++ b/src/test/resources/bus_test_send_5.js
@@ -1,4 +1,4 @@
-var EventBus = require('vertx-js/vertx-eventbus');
+var EventBus = require('./vertx-js/vertx-eventbus');
 var bus = new EventBus();
 
 bus.onopen = function () {

--- a/src/test/resources/bus_test_send_5.js
+++ b/src/test/resources/bus_test_send_5.js
@@ -1,4 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
 var bus = new EventBus();
 
 bus.onopen = function () {

--- a/src/test/resources/bus_test_send_6.js
+++ b/src/test/resources/bus_test_send_6.js
@@ -1,4 +1,4 @@
-var EventBus = require('vertx-js/vertx-eventbus');
+var EventBus = require('./vertx-js/vertx-eventbus');
 var bus = new EventBus();
 
 bus.onopen = function () {

--- a/src/test/resources/bus_test_send_6.js
+++ b/src/test/resources/bus_test_send_6.js
@@ -1,4 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
 var bus = new EventBus();
 
 bus.onopen = function () {

--- a/src/test/resources/node_modules/sockjs-client.js
+++ b/src/test/resources/node_modules/sockjs-client.js
@@ -1,15 +1,17 @@
 /**
  * This is a Proxy to emulate the SockJS client
  */
+const JsonObject = Java.type('io.vertx.core.json.JsonObject');
+const DeliveryOptions = Java.type('io.vertx.core.eventbus.DeliveryOptions');
 
 function wrapBody(body) {
   var json = JSON.stringify(body);
-  return new Packages.io.vertx.core.json.JsonObject(json);
+  return new JsonObject(json);
 }
 
 function unwrapMsg(msg) {
-  var json = new Packages.io.vertx.core.json.JsonObject();
-  var headers = new Packages.io.vertx.core.json.JsonObject();
+  var json = new JsonObject();
+  var headers = new JsonObject();
   var msgHeaders = msg.headers();
   for (var i = msgHeaders.names().iterator();i.hasNext();) {
     var headerName = i.next();
@@ -21,7 +23,7 @@ function unwrapMsg(msg) {
 }
 
 function wrapHeaders(headers) {
-  var ret = new Packages.io.vertx.core.eventbus.DeliveryOptions();
+  var ret = new DeliveryOptions();
   if (typeof headers !== 'undefined') {
     for (var name in headers) {
       if (headers.hasOwnProperty(name)) {
@@ -80,7 +82,7 @@ SockJS.prototype.send = function(string) {
   };
 
   if (address) {
-    var eb = vertx._jdel.eventBus();
+    var eb = vertx.eventBus();
 
     switch (json.type) {
       case 'send':

--- a/src/test/resources/node_modules/sockjs-client.js
+++ b/src/test/resources/node_modules/sockjs-client.js
@@ -1,3 +1,45 @@
+function setTimeout(callback, timeout) {
+  const args = Array.prototype.slice.call(arguments, 2);
+
+  if (Number(timeout) === 0) {
+    // special case
+    vertx.runOnContext(function (v) {
+      callback.apply(globalThis, args);
+    });
+  } else {
+    return vertx.setTimer(Number(timeout), function (t) {
+      callback(globalThis, args);
+    });
+  }
+}
+
+function setInterval(callback, timeout) {
+  const args = Array.prototype.slice.call(arguments, 2);
+
+  if (Number(timeout) === 0) {
+    // special case
+    vertx.runOnContext(function (v) {
+      callback.apply(globalThis, args);
+    });
+  } else {
+    return vertx.setPeriodic(Number(timeout), function (t) {
+      callback.apply(globalThis, args);
+    });
+  }
+}
+
+function clearTimeout(id) {
+  if (id !== undefined) {
+    return vertx.cancelTimer(id);
+  }
+}
+
+function clearInterval(id) {
+  if (id !== undefined) {
+    return vertx.cancelTimer(id);
+  }
+}
+
 /**
  * This is a Proxy to emulate the SockJS client
  */
@@ -108,5 +150,3 @@ SockJS.prototype.send = function(string) {
 SockJS.prototype.close = function() {
   this.onclose && this.onclose();
 };
-
-module.exports = SockJS;

--- a/src/test/resources/test_service_basicBoxedTypes.js
+++ b/src/test/resources/test_service_basicBoxedTypes.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_basicBoxedTypes.js
+++ b/src/test/resources/test_service_basicBoxedTypes.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_basicTypes.js
+++ b/src/test/resources/test_service_basicTypes.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_basicTypes.js
+++ b/src/test/resources/test_service_basicTypes.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_byteHandler.js
+++ b/src/test/resources/test_service_byteHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_byteHandler.js
+++ b/src/test/resources/test_service_byteHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_byteNullHandler.js
+++ b/src/test/resources/test_service_byteNullHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_byteNullHandler.js
+++ b/src/test/resources/test_service_byteNullHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_charHandler.js
+++ b/src/test/resources/test_service_charHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_charHandler.js
+++ b/src/test/resources/test_service_charHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_charNullHandler.js
+++ b/src/test/resources/test_service_charNullHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_charNullHandler.js
+++ b/src/test/resources/test_service_charNullHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_connection.js
+++ b/src/test/resources/test_service_connection.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_connection.js
+++ b/src/test/resources/test_service_connection.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_connectionTimeout.js
+++ b/src/test/resources/test_service_connectionTimeout.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_connectionTimeout.js
+++ b/src/test/resources/test_service_connectionTimeout.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_connectionWithCloseFutureTimeout.js
+++ b/src/test/resources/test_service_connectionWithCloseFutureTimeout.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_connectionWithCloseFutureTimeout.js
+++ b/src/test/resources/test_service_connectionWithCloseFutureTimeout.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_dataObjectHandler.js
+++ b/src/test/resources/test_service_dataObjectHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_dataObjectHandler.js
+++ b/src/test/resources/test_service_dataObjectHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_dataObjectNullHandler.js
+++ b/src/test/resources/test_service_dataObjectNullHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_dataObjectNullHandler.js
+++ b/src/test/resources/test_service_dataObjectNullHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_dataObjectType.js
+++ b/src/test/resources/test_service_dataObjectType.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_dataObjectType.js
+++ b/src/test/resources/test_service_dataObjectType.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_doubleHandler.js
+++ b/src/test/resources/test_service_doubleHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_doubleHandler.js
+++ b/src/test/resources/test_service_doubleHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_doubleNullHandler.js
+++ b/src/test/resources/test_service_doubleNullHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_doubleNullHandler.js
+++ b/src/test/resources/test_service_doubleNullHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_enumType.js
+++ b/src/test/resources/test_service_enumType.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_enumType.js
+++ b/src/test/resources/test_service_enumType.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_failingMethod.js
+++ b/src/test/resources/test_service_failingMethod.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_failingMethod.js
+++ b/src/test/resources/test_service_failingMethod.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_floatHandler.js
+++ b/src/test/resources/test_service_floatHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_floatHandler.js
+++ b/src/test/resources/test_service_floatHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_floatNullHandler.js
+++ b/src/test/resources/test_service_floatNullHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_floatNullHandler.js
+++ b/src/test/resources/test_service_floatNullHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_fluentMethod.js
+++ b/src/test/resources/test_service_fluentMethod.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_fluentMethod.js
+++ b/src/test/resources/test_service_fluentMethod.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_fluentNoParams.js
+++ b/src/test/resources/test_service_fluentNoParams.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_fluentNoParams.js
+++ b/src/test/resources/test_service_fluentNoParams.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_intHandler.js
+++ b/src/test/resources/test_service_intHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_intHandler.js
+++ b/src/test/resources/test_service_intHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_intNullHandler.js
+++ b/src/test/resources/test_service_intNullHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_intNullHandler.js
+++ b/src/test/resources/test_service_intNullHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_invalidParams.js
+++ b/src/test/resources/test_service_invalidParams.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_invalidParams.js
+++ b/src/test/resources/test_service_invalidParams.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_jsonArrayHandler.js
+++ b/src/test/resources/test_service_jsonArrayHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_jsonArrayHandler.js
+++ b/src/test/resources/test_service_jsonArrayHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_jsonArrayNullHandler.js
+++ b/src/test/resources/test_service_jsonArrayNullHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_jsonArrayNullHandler.js
+++ b/src/test/resources/test_service_jsonArrayNullHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_jsonObjectHandler.js
+++ b/src/test/resources/test_service_jsonObjectHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_jsonObjectHandler.js
+++ b/src/test/resources/test_service_jsonObjectHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_jsonObjectNullHandler.js
+++ b/src/test/resources/test_service_jsonObjectNullHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_jsonObjectNullHandler.js
+++ b/src/test/resources/test_service_jsonObjectNullHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_jsonTypes.js
+++ b/src/test/resources/test_service_jsonTypes.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_jsonTypes.js
+++ b/src/test/resources/test_service_jsonTypes.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_listBoolHandler.js
+++ b/src/test/resources/test_service_listBoolHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_listBoolHandler.js
+++ b/src/test/resources/test_service_listBoolHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_listByteHandler.js
+++ b/src/test/resources/test_service_listByteHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_listByteHandler.js
+++ b/src/test/resources/test_service_listByteHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_listCharHandler.js
+++ b/src/test/resources/test_service_listCharHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_listCharHandler.js
+++ b/src/test/resources/test_service_listCharHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_listDataObjectHandler.js
+++ b/src/test/resources/test_service_listDataObjectHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_listDataObjectHandler.js
+++ b/src/test/resources/test_service_listDataObjectHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_listDoubleHandler.js
+++ b/src/test/resources/test_service_listDoubleHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_listDoubleHandler.js
+++ b/src/test/resources/test_service_listDoubleHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_listFloatHandler.js
+++ b/src/test/resources/test_service_listFloatHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_listFloatHandler.js
+++ b/src/test/resources/test_service_listFloatHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_listIntHandler.js
+++ b/src/test/resources/test_service_listIntHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_listIntHandler.js
+++ b/src/test/resources/test_service_listIntHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_listJsonArrayHandler.js
+++ b/src/test/resources/test_service_listJsonArrayHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_listJsonArrayHandler.js
+++ b/src/test/resources/test_service_listJsonArrayHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_listJsonObjectHandler.js
+++ b/src/test/resources/test_service_listJsonObjectHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_listJsonObjectHandler.js
+++ b/src/test/resources/test_service_listJsonObjectHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_listLongHandler.js
+++ b/src/test/resources/test_service_listLongHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_listLongHandler.js
+++ b/src/test/resources/test_service_listLongHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_listShortHandler.js
+++ b/src/test/resources/test_service_listShortHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_listShortHandler.js
+++ b/src/test/resources/test_service_listShortHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_listStringHandler.js
+++ b/src/test/resources/test_service_listStringHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_listStringHandler.js
+++ b/src/test/resources/test_service_listStringHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_listTypes.js
+++ b/src/test/resources/test_service_listTypes.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_listTypes.js
+++ b/src/test/resources/test_service_listTypes.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_longDeliveryFailed.js
+++ b/src/test/resources/test_service_longDeliveryFailed.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_longDeliveryFailed.js
+++ b/src/test/resources/test_service_longDeliveryFailed.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_longDeliverySuccess.js
+++ b/src/test/resources/test_service_longDeliverySuccess.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_longDeliverySuccess.js
+++ b/src/test/resources/test_service_longDeliverySuccess.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_longHandler.js
+++ b/src/test/resources/test_service_longHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_longHandler.js
+++ b/src/test/resources/test_service_longHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_longNullHandler.js
+++ b/src/test/resources/test_service_longNullHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_longNullHandler.js
+++ b/src/test/resources/test_service_longNullHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_mapTypes.js
+++ b/src/test/resources/test_service_mapTypes.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_mapTypes.js
+++ b/src/test/resources/test_service_mapTypes.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_noParams.js
+++ b/src/test/resources/test_service_noParams.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_noParams.js
+++ b/src/test/resources/test_service_noParams.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_proxyIgnore.js
+++ b/src/test/resources/test_service_proxyIgnore.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_proxyIgnore.js
+++ b/src/test/resources/test_service_proxyIgnore.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_setBoolHandler.js
+++ b/src/test/resources/test_service_setBoolHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_setBoolHandler.js
+++ b/src/test/resources/test_service_setBoolHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_setByteHandler.js
+++ b/src/test/resources/test_service_setByteHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_setByteHandler.js
+++ b/src/test/resources/test_service_setByteHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_setCharHandler.js
+++ b/src/test/resources/test_service_setCharHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_setCharHandler.js
+++ b/src/test/resources/test_service_setCharHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_setDataObjectHandler.js
+++ b/src/test/resources/test_service_setDataObjectHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_setDataObjectHandler.js
+++ b/src/test/resources/test_service_setDataObjectHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_setDoubleHandler.js
+++ b/src/test/resources/test_service_setDoubleHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_setDoubleHandler.js
+++ b/src/test/resources/test_service_setDoubleHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_setFloatHandler.js
+++ b/src/test/resources/test_service_setFloatHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_setFloatHandler.js
+++ b/src/test/resources/test_service_setFloatHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_setIntHandler.js
+++ b/src/test/resources/test_service_setIntHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_setIntHandler.js
+++ b/src/test/resources/test_service_setIntHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_setJsonArrayHandler.js
+++ b/src/test/resources/test_service_setJsonArrayHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_setJsonArrayHandler.js
+++ b/src/test/resources/test_service_setJsonArrayHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_setJsonObjectHandler.js
+++ b/src/test/resources/test_service_setJsonObjectHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_setJsonObjectHandler.js
+++ b/src/test/resources/test_service_setJsonObjectHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_setLongHandler.js
+++ b/src/test/resources/test_service_setLongHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_setLongHandler.js
+++ b/src/test/resources/test_service_setLongHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_setShortHandler.js
+++ b/src/test/resources/test_service_setShortHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_setShortHandler.js
+++ b/src/test/resources/test_service_setShortHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_setStringHandler.js
+++ b/src/test/resources/test_service_setStringHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_setStringHandler.js
+++ b/src/test/resources/test_service_setStringHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_setTypes.js
+++ b/src/test/resources/test_service_setTypes.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_setTypes.js
+++ b/src/test/resources/test_service_setTypes.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_shortHandler.js
+++ b/src/test/resources/test_service_shortHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_shortHandler.js
+++ b/src/test/resources/test_service_shortHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_shortNullHandler.js
+++ b/src/test/resources/test_service_shortNullHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_shortNullHandler.js
+++ b/src/test/resources/test_service_shortNullHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_stringHandler.js
+++ b/src/test/resources/test_service_stringHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_stringHandler.js
+++ b/src/test/resources/test_service_stringHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_stringNullHandler.js
+++ b/src/test/resources/test_service_stringNullHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_stringNullHandler.js
+++ b/src/test/resources/test_service_stringNullHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_testShortHandler.js
+++ b/src/test/resources/test_service_testShortHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_testShortHandler.js
+++ b/src/test/resources/test_service_testShortHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 

--- a/src/test/resources/test_service_voidHandler.js
+++ b/src/test/resources/test_service_voidHandler.js
@@ -1,6 +1,3 @@
-var EventBus = require('./vertx-js/vertx-eventbus');
-var TestService = require('./test-js/test_service-proxy');
-
 var eb = new EventBus();
 
 eb.onopen = function () {

--- a/src/test/resources/test_service_voidHandler.js
+++ b/src/test/resources/test_service_voidHandler.js
@@ -1,5 +1,5 @@
-var EventBus = require('vertx-js/vertx-eventbus');
-var TestService = require('test-js/test_service-proxy');
+var EventBus = require('./vertx-js/vertx-eventbus');
+var TestService = require('./test-js/test_service-proxy');
 
 var eb = new EventBus();
 


### PR DESCRIPTION
Currently we aren't running any tests. This PR will ensure we run the tests against es4x.

The PR will require a few prerequisites:

1. The PR on es4x https://github.com/reactiverse/es4x/pull/338 must be merged

This is because the verticle factory and future APIs have changed on core and they need to be properly aligned.