### PR TITLE
Avoid graaljs single thread limitation on tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <codegen.rxjava.deprecated>true</codegen.rxjava.deprecated>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
-    <graalvm.version>20.0.0</graalvm.version>
+    <graalvm.version>20.1.0</graalvm.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
 

--- a/src/test/java/io/vertx/serviceproxy/test/JSServiceProxyTest.java
+++ b/src/test/java/io/vertx/serviceproxy/test/JSServiceProxyTest.java
@@ -1,5 +1,6 @@
 package io.vertx.serviceproxy.test;
 
+import io.vertx.core.VertxOptions;
 import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.serviceproxy.Addresses;
@@ -22,6 +23,11 @@ public class JSServiceProxyTest extends VertxTestBase {
   MessageConsumer<JsonObject> consumer;
 
   @Override
+  protected VertxOptions getOptions() {
+    return new VertxOptions().setEventLoopPoolSize(1);
+  }
+
+    @Override
   public void setUp() throws Exception {
     super.setUp();
     service = TestService.create(vertx);


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

GraalJs is strict single thread, so during tests that use eventbus state may leak and cause testing issues. Forcing the number of event loops to 1 makes this to go away and allow full testing.